### PR TITLE
Add support for textContent

### DIFF
--- a/lib/document-fragment.js
+++ b/lib/document-fragment.js
@@ -6,7 +6,11 @@ function DocumentFragment () {
 }
 
 DocumentFragment.prototype = {
-  querySelector, querySelectorAll, getElementsByTagName
+  querySelector, querySelectorAll, getElementsByTagName,
+
+  get textContent () {
+    return null;
+  }
 };
 
 export default DocumentFragment;

--- a/lib/document.js
+++ b/lib/document.js
@@ -6,7 +6,11 @@ function Document () {
 }
 
 Document.prototype = {
-  querySelector, querySelectorAll, getElementsByTagName
+  querySelector, querySelectorAll, getElementsByTagName,
+
+  get textContent () {
+    return null;
+  }
 };
 
 export default Document;

--- a/lib/element.js
+++ b/lib/element.js
@@ -40,6 +40,10 @@ Element.prototype = {
     return attributes.length
       ? `<${this.tagName} ${attributes}>${this.innerHTML}</${this.tagName}>`
       : `<${this.tagName}>${this.innerHTML}</${this.tagName}>`;
+  },
+
+  get textContent () {
+    return this.childNodes.map(child => child.textContent).join('');
   }
 };
 

--- a/lib/insert-text.js
+++ b/lib/insert-text.js
@@ -4,6 +4,12 @@ function Text (data) {
   this.parentNode = null;
 }
 
+Text.prototype = {
+  get textContent () {
+    return this.data;
+  }
+};
+
 export default treeAdapter => (parentNode, text) => {
   if (parentNode.childNodes.length) {
     var prevNode = parentNode.childNodes[parentNode.childNodes.length - 1];

--- a/test.js
+++ b/test.js
@@ -243,6 +243,44 @@ test('element().outerHTML', t => {
   t.is(expected, actual);
 });
 
+test('#text.textContent', t => {
+  const actual = parseFragment('beep beep').childNodes[0].textContent;
+  const expected = 'beep beep';
+  t.is(actual, expected);
+});
+
+test('element().textContent', t => {
+  const actual = parseFragment(tsml`
+    <div><flipp>Foo <flopp>Bar</flopp></flipp>Fred</div>
+  `).childNodes[0].textContent;
+  const expected = 'Foo BarFred';
+  t.is(actual, expected);
+});
+
+test('element().textContent preserves whitespace', t => {
+  const actual = parseFragment(`<div>
+    <flipp>Foo
+      <flopp>Bar</flopp>
+    </flipp>
+    Fred
+  </div>`).childNodes[0].textContent;
+  const expected = '\n    Foo\n      Bar\n    \n    Fred\n  ';
+  t.is(actual, expected);
+});
+
+test('document().textContent is null', t => {
+  const actual = parse(`<!DOCTYPE html5>
+    <p>Hello</p>
+  </div>`).textContent;
+  t.is(actual, null);
+});
+
+test('documentFragment().textContent is null', t => {
+  const actual = parseFragment(`<p>Hello</p>
+  </div>`).textContent;
+  t.is(actual, null);
+});
+
 test('legacy', t => {
   const html = tsml`
     <flipp><flopp></flopp></flipp>


### PR DESCRIPTION
An attempt to support the Node.[textContent](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) property. 

BTW nice library, the combo of parse5 and cssauron feels more solid than cheerio ;)

Any plans to add more of the DOM standard?