### PR TITLE
Support attribute selectors

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -3,7 +3,7 @@ import css from 'cssauron-html';
 const queryOne = (childNodes, selector) => {
   for (var i = 0; i < childNodes.length; i++) {
     let elm = childNodes[i];
-    if (selector(elm)) {
+    if (elm.tagName && selector(elm)) {
       return elm;
     }
     if (elm.childNodes) {
@@ -18,7 +18,7 @@ const queryOne = (childNodes, selector) => {
 const queryAll = (childNodes, selector, result) => {
   for (var i = 0; i < childNodes.length; i++) {
     let elm = childNodes[i];
-    if (selector(elm)) {
+    if (elm.tagName && selector(elm)) {
       result.push(elm);
     }
     if (elm.childNodes) {

--- a/lib/query.js
+++ b/lib/query.js
@@ -1,4 +1,14 @@
-import css from 'cssauron-html';
+import cssauron from 'cssauron';
+
+const css = cssauron({
+  tag: node => node.tagName,
+  contents: node => node.textContent,
+  id: node => node.getAttribute('id'),
+  'class': node => node.getAttribute('class'),
+  'parent': 'parentNode',
+  children: node => node.childNodes.filter(child => child.tagName),
+  attr: (node, attr) => node.getAttribute(attr) || ''
+});
 
 const queryOne = (childNodes, selector) => {
   for (var i = 0; i < childNodes.length; i++) {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "camelcase-css": "^1.0.0",
-    "cssauron-html": "^1.0.0",
+    "cssauron": "^1.4.0",
     "object-assign": "^4.0.1",
     "parse5": "^2.1.5",
     "to-fast-properties": "^1.0.1"

--- a/test.js
+++ b/test.js
@@ -281,14 +281,71 @@ test('documentFragment().textContent is null', t => {
   t.is(actual, null);
 });
 
-test('parse().querySelectorAll(attr)', t => {
+test('parse().querySelectorAll(#id)', t => {
   const actual = parse(`<div>
-    <beep><foo data-name="foo"></foo></beep>
+    <beep><foo id="bar"></foo></beep>
     <foo></foo>
-  </div>`).querySelectorAll('[data-name="foo"]');
+  </div>`).querySelectorAll('#bar');
   t.is(actual.length, 1);
   t.is(actual[0].tagName, 'foo');
-  t.is(actual[0].parentNode.tagName, 'beep');
+});
+
+test('parse().querySelectorAll(.class)', t => {
+  const actual = parse(`<div>
+    <beep><foo class="bar"></foo></beep>
+    <foo></foo>
+  </div>`).querySelectorAll('.bar');
+  t.is(actual.length, 1);
+  t.is(actual[0].tagName, 'foo');
+});
+
+test('parse().querySelectorAll(tag > #id)', t => {
+  const actual = parse(`<div>
+    <beep><foo id="bar"></foo></beep>
+    <foo></foo>
+  </div>`).querySelectorAll('beep #bar');
+  t.is(actual.length, 1);
+  t.is(actual[0].tagName, 'foo');
+});
+
+test('parse().querySelectorAll(tag + tag)', t => {
+  const actual = parse(`<div>
+    <beep><span></span><foo></foo></beep>
+    <foo></foo>
+  </div>`).querySelectorAll('span + foo');
+  t.is(actual.length, 1);
+  t.is(actual[0].tagName, 'foo');
+});
+
+test('parse().querySelectorAll([attr=value])', t => {
+  const actual = parse(`<div>
+    <beep><foo data-name="bar"></foo></beep>
+    <foo></foo>
+  </div>`).querySelectorAll('[data-name="bar"]');
+  t.is(actual.length, 1);
+  t.is(actual[0].getAttribute('data-name'), 'bar');
+});
+
+test('parse().querySelectorAll([attr^=value])', t => {
+  const actual = parse(`<div>
+    <beep><foo data-name="foo-bar"></foo></beep>
+    <beep><bar data-name="bar-foo"></bar></beep>
+    <foo></foo>
+  </div>`).querySelectorAll('[data-name^="foo"]');
+  t.is(actual.length, 1);
+  t.is(actual[0].tagName, 'foo');
+  t.is(actual[0].getAttribute('data-name'), 'foo-bar');
+});
+
+test('parse().querySelectorAll(:contains())', t => {
+  const actual = parse(`<div>
+    <beep>qux it</beep>
+    <beep><bar></bar>it qux</beep>
+    <foo>quuux</foo>
+  </div>`).querySelectorAll('beep:contains("qux")');
+  t.is(actual.length, 2);
+  t.is(actual[0].textContent, 'qux it');
+  t.is(actual[1].textContent, 'it qux');
 });
 
 test('legacy', t => {

--- a/test.js
+++ b/test.js
@@ -281,6 +281,16 @@ test('documentFragment().textContent is null', t => {
   t.is(actual, null);
 });
 
+test('parse().querySelectorAll(attr)', t => {
+  const actual = parse(`<div>
+    <beep><foo data-name="foo"></foo></beep>
+    <foo></foo>
+  </div>`).querySelectorAll('[data-name="foo"]');
+  t.is(actual.length, 1);
+  t.is(actual[0].tagName, 'foo');
+  t.is(actual[0].parentNode.tagName, 'beep');
+});
+
 test('legacy', t => {
   const html = tsml`
     <flipp><flopp></flopp></flipp>


### PR DESCRIPTION
I found a couple of bugs with attribute selectors:

1. The `querySelector` implementation attempted to match any node type, but then using an attribute selector causes `getAttribute` to be called on a non-element which throws an error - the fix was to restrict the tested nodes to elements with a `tagName`.

2. `cssauron-html` has it's own bugs, like not handling `null` being returned for `getAttribute` - it attempts a regex on it regardless (or rather the main `cssauron` does). I dropped `cssauron-html` in favour of vanilla `cssauron` with options configured to match `parse5`/`query-dom` tree. That specific bug is fixed by always returning a string. I added a bunch more selector tests to check everything works as expected, and maintain the 100% coverage :)